### PR TITLE
German Add

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,26 +29,15 @@ function App() {
           <Share />
         </Route>
 
-        <Route exact path='/he'>
-          <Pronoun pronoun='he' />
-          <Example pronoun='he' />
+        {['/he', '/she', '/they', '/er', '/sie', '/xier'].map(path => {
+          const pronoun = path.substring(1);
+          return (<Route exact path={path}>
+          <Pronoun pronoun={pronoun} />
+          <Example pronoun={pronoun} />
           <Importance />
           <Share />
-        </Route>
-
-        <Route exact path='/she'>
-          <Pronoun pronoun='she' />
-          <Example pronoun='she' />
-          <Importance />
-          <Share />
-        </Route>
-
-        <Route exact path='/they'>
-          <Pronoun pronoun='they' />
-          <Example pronoun='they' />
-          <Importance />
-          <Share />
-        </Route>
+        </Route>)
+        })}
 
         <Route exact path='/attack-helicopter'>
           <Pronoun pronoun='attack-helicopter' />

--- a/src/components/Example.js
+++ b/src/components/Example.js
@@ -44,19 +44,24 @@ function Example(props) {
 
       {props.pronoun === 'sie' ? (
         <p className='text-gray-900 md:text-lg lg:text-xl'>
-          <span className='italic'>They</span> were laughing when I called{' '}
-          <span className='italic'>them</span> last week. I can tell that I made{' '}
-          <span className='italic'>their</span> day. I'm happy they love{' '}
-          <span className='italic'>themself</span> a lot.
+          <span className='italic'>Sie</span> lachte, als ich{' '}
+          <span className='italic'>sie</span> letzte Woche anrief. Ich kann sagen, dass ich{' '}
+          <span className='italic'>ihren</span> Tag gemacht habe. Ich bin froh, dass sie{' '}
+          <span className='italic'>sich</span> sehr liebt.
+        <br/>
+        <span className='italic'>Sie</span> lachten, als ich{' '}
+          <span className='italic'>sie</span> letzte Woche anrief. Ich kann sagen, dass ich{' '}
+          <span className='italic'>ihren</span> Tag gemacht habe. Ich bin froh, dass sie{' '}
+          <span className='italic'>sich</span> sehr lieben.
         </p>
       ) : null}
 
       {props.pronoun === 'xier' ? (
         <p className='text-gray-900 md:text-lg lg:text-xl'>
-          <span className='italic'>They</span> were laughing when I called{' '}
-          <span className='italic'>them</span> last week. I can tell that I made{' '}
-          <span className='italic'>their</span> day. I'm happy they love{' '}
-          <span className='italic'>themself</span> a lot.
+          <span className='italic'>Xier</span> lachte, als ich{' '}
+          <span className='italic'>xien</span> letzte Woche anrief. Ich kann sagen, dass ich{' '}
+          <span className='italic'>xiesen</span> Tag gemacht habe. Ich bin froh, dass xier{' '}
+          <span className='italic'>sich</span> sehr liebt.
         </p>
       ) : null}
 

--- a/src/components/Example.js
+++ b/src/components/Example.js
@@ -33,6 +33,33 @@ function Example(props) {
         </p>
       ) : null}
 
+      {props.pronoun === 'er' ? (
+        <p className='text-gray-900 md:text-lg lg:text-xl'>
+          <span className='italic'>Er</span> lachte, als ich{' '}
+          <span className='italic'>ihn</span> letzte Woche anrief. Ich kann sagen, dass ich{' '}
+          <span className='italic'>seinen</span> Tag gemacht habe. Ich bin froh, dass er{' '}
+          <span className='italic'>sich</span> sehr liebt.
+        </p>
+      ) : null}
+
+      {props.pronoun === 'sie' ? (
+        <p className='text-gray-900 md:text-lg lg:text-xl'>
+          <span className='italic'>They</span> were laughing when I called{' '}
+          <span className='italic'>them</span> last week. I can tell that I made{' '}
+          <span className='italic'>their</span> day. I'm happy they love{' '}
+          <span className='italic'>themself</span> a lot.
+        </p>
+      ) : null}
+
+      {props.pronoun === 'xier' ? (
+        <p className='text-gray-900 md:text-lg lg:text-xl'>
+          <span className='italic'>They</span> were laughing when I called{' '}
+          <span className='italic'>them</span> last week. I can tell that I made{' '}
+          <span className='italic'>their</span> day. I'm happy they love{' '}
+          <span className='italic'>themself</span> a lot.
+        </p>
+      ) : null}
+
       {props.pronoun === 'attack-helicopter' ? (
         <p className='text-gray-900 md:text-lg lg:text-xl'>
           <span className='italic'>Attack helicopter</span> went

--- a/src/components/Pronoun.js
+++ b/src/components/Pronoun.js
@@ -43,7 +43,7 @@ function Pronoun(props) {
       {props.pronoun === 'sie' ? (
         <p className='text-gray-900 md:text-lg lg:text-xl'>
         Meine Pronomen sind{' '}
-        <span className='font-bold text-grey-800'>sie, sie, ihre sein oder sie, ihnen, ihre</span>
+        <span className='font-bold text-grey-800'>sie, sie, ihre, oder sie, ihnen, ihre</span>
         .  Dies spiegelt nicht unbedingt mein Geschlecht oder meine
          sexuelle Orientierung wider.
         </p>
@@ -52,8 +52,8 @@ function Pronoun(props) {
       {props.pronoun === 'xier' ? (
         <p className='text-gray-900 md:text-lg lg:text-xl'>
         Meine Pronomen sind{' '}
-        <span className='font-bold text-grey-800'>xier, xies, xiem</span>
-        . Ausgesprochen: [ksi:ɐ̯];  Für eine Person jeden Geschlechts.  Dies spiegelt nicht unbedingt mein Geschlecht oder meine
+        <span className='font-bold text-grey-800'>xier, xiem, xies</span>
+        .  Ausgesprochen: [ksi:ɐ̯].  Für eine Person jeden Geschlechts.  Dies spiegelt nicht unbedingt mein Geschlecht oder meine
          sexuelle Orientierung wider.
         </p>
       ) : null}

--- a/src/components/Pronoun.js
+++ b/src/components/Pronoun.js
@@ -31,6 +31,33 @@ function Pronoun(props) {
         </p>
       ) : null}
 
+      {props.pronoun === 'er' ? (
+        <p className='text-gray-900 md:text-lg lg:text-xl'>
+        Meine Pronomen sind{' '}
+        <span className='font-bold text-grey-800'>er, ihn, sein</span>
+        .  Dies spiegelt nicht unbedingt mein Geschlecht oder meine
+         sexuelle Orientierung wider.
+        </p>
+      ) : null}
+
+      {props.pronoun === 'sie' ? (
+        <p className='text-gray-900 md:text-lg lg:text-xl'>
+        Meine Pronomen sind{' '}
+        <span className='font-bold text-grey-800'>sie, sie, ihre sein oder sie, ihnen, ihre</span>
+        .  Dies spiegelt nicht unbedingt mein Geschlecht oder meine
+         sexuelle Orientierung wider.
+        </p>
+      ) : null}
+
+      {props.pronoun === 'xier' ? (
+        <p className='text-gray-900 md:text-lg lg:text-xl'>
+        Meine Pronomen sind{' '}
+        <span className='font-bold text-grey-800'>xier, xies, xiem</span>
+        . Ausgesprochen: [ksi:ɐ̯];  Für eine Person jeden Geschlechts.  Dies spiegelt nicht unbedingt mein Geschlecht oder meine
+         sexuelle Orientierung wider.
+        </p>
+      ) : null}
+
       {props.pronoun === 'attack-helicopter' ? (
         <div>
           <p className='text-gray-900 md:text-lg lg:text-xl'>


### PR DESCRIPTION
Closes #1 
Adds german to the supported pronouns for: er, sie, xier
I chose not to modify the landing page to show support for these at your disgression
I had to do a little research for xier, since handling non-binary pronouns in German is still a fairly recent thing
So that may need tweaking if someone with more knowledge ever takes a look 

This does also modify the App.js, rather than add new routes individually, I map an Array and mapped all of them to the correct components, stripping off the / as needed.